### PR TITLE
feat: production dockerfile optimization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,8 @@ node_modules
 Dockerfile
 .git
 .gitignore
+.github
+.env
+.husky
+.swc
+docker

--- a/docker/Dockerfile.production
+++ b/docker/Dockerfile.production
@@ -1,4 +1,5 @@
-FROM node:18-alpine as base
+# Base Stage
+FROM node:18-alpine AS base
 
 WORKDIR /app
 
@@ -6,10 +7,33 @@ COPY package.json yarn.lock ./
 
 RUN yarn install --frozen-lockfile
 
+# Build Stage
+FROM node:18-alpine AS builder
+
 ENV NODE_ENV=production
 
-RUN yarn build
+WORKDIR /app
 
 COPY . .
+
+COPY --from=base /app/node_modules ./node_modules
+
+# Build the application using the appropriate build script (defined in package.json)
+# Remove the Next.js cache to reduce memory usage
+RUN yarn build \
+    && rm -rf ./.next/cache
+
+# Run Stage
+FROM node:18-alpine AS production
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/next.config.js ./next.config.js
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
 
 CMD ["yarn", "start"]

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
## Why need this change? / Root cause:

- original production Dockerfile can not build successfully because it run build before copy the content
- after change the order, we can build successfully, but I found that the image size is too big (3.xxGB)
- I choose to use [multi-stage build](https://docs.docker.com/build/building/multi-stage/) to minimize the image size, and the result is as below

Before optimization: 3.4 GB 🥵
![截圖 2023-05-25 下午3 32 29](https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/35811214/9913d114-ecbf-4f89-bb7e-d0e48fcb229a)

After optimization: 871 MB 🥺
![截圖 2023-05-25 下午4 10 06](https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/35811214/d12a224c-c591-4da8-994d-adf58b925d4b)

It is almost 4 times smaller.

- add `next.config.js`, I think we may need this file to add some config in the near future. In this PR, we set lint to ignoreDuringBuilds because we plan to run lint in pre-commit step, which can make build step quicker

## Changes made:

-

## Test Scope / Change impact:

- Although we do not use docker for deployment now, maybe we will need it if we migrate to k8s or ECS in the future

## Issue

-
