### PR TITLE
refactor: extract pull-request workflow to multi jobs & restore cache

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -26,7 +26,7 @@ jobs:
           path: |
             node_modules
             ~/.cache/Cypress
-          key: deps-node-modules-${{ hashFiles('**/yarn.lock') }}
+          key: deps-node-modules-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/*.[jt]s', '**/*.[jt]sx') }}
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -26,6 +26,7 @@ jobs:
           path: |
             node_modules
             ~/.cache/Cypress
+            ${{ github.workspace }}/.next/cache
           key: deps-node-modules-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/*.[jt]s', '**/*.[jt]sx') }}
 
       - name: Install dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
         run: yarn install --frozen-lockfile
             
       - name: Test
-          run: yarn test
+        run: yarn test
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,4 +89,4 @@ jobs:
         run: yarn install --frozen-lockfile
         
       - name: lint
-        run: npx eslint@7.32.0 --no-error-on-unmatched-pattern -c .eslintrc.js $(git diff --name-only --relative --diff-filter=ACMRTUXB HEAD~1 | grep  -E ".(js|jsx|ts|tsx)$")
+        run: npx eslint@7.32.0 --no-error-on-unmatched-pattern -c .eslintrc.json $(git diff --name-only --relative --diff-filter=ACMRTUXB HEAD~1 | grep  -E ".(js|jsx|ts|tsx)$")

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,19 +9,84 @@ env:
   APPLICATION_FOLDER: ~/game-lobby/frontend
 
 jobs:
-  build_and_test:
-    name: Build and Test
+  build:
+    name: Build
     runs-on: ubuntu-latest
 
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - name: Cache dependencies
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            ~/.cache/Cypress
+            ${{ github.workspace }}/.next/cache
+          # Generate a new cache whenever packages or source files change.
+          key: deps-node-modules-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/*.[jt]s', '**/*.[jt]sx') }}
+          restore-keys: |
+            deps-node-modules-${{ hashFiles('**/yarn.lock') }}-
 
-      - name: Test
-        run: yarn test
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
 
       - name: Build
         run: yarn build
+  
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+
+      - name: Cache dependencies
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            ~/.cache/Cypress
+            ${{ github.workspace }}/.next/cache
+          key: deps-node-modules-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/*.[jt]s', '**/*.[jt]sx') }}
+          restore-keys: |
+            deps-node-modules-${{ hashFiles('**/yarn.lock') }}-
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+            
+      - name: Test
+          run: yarn test
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+
+      - name: Cache dependencies
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            ~/.cache/Cypress
+            ${{ github.workspace }}/.next/cache
+          key: deps-node-modules-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/*.[jt]s', '**/*.[jt]sx') }}
+          restore-keys: |
+            deps-node-modules-${{ hashFiles('**/yarn.lock') }}-
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+        
+      - name: lint
+        run: npx eslint@7.32.0 --no-error-on-unmatched-pattern -c .eslintrc.js $(git diff --name-only --relative --diff-filter=ACMRTUXB HEAD~1 | grep  -E ".(js|jsx|ts|tsx)$")


### PR DESCRIPTION
## Why need this change? / Root cause:

- The original unified workflow has been broken down into multiple jobs: `build`, `test`, and `lint`. Both `lint` and `test` jobs are designed to run in parallel once the `build` job completes. This arrangement offers the benefit of maximizing pipeline execution speed in the future when there are other steps that also depend on the results of the build job.
- By utilizing the cache action and using the hash values of `yarn.lock` and the source code (ts, tsx, js, jsx) as the cache keys, theoretically, both `lint` and `test` jobs can make use of the cache created during the build step, eliminating the need to reinstall dependencies.

| lint (cache hit) | test (cache hit) |
|-----|-------|
| ![圖片](https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/35811214/7db3e98f-1be3-467b-8298-0086aa32735e) | ![圖片](https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/35811214/4a2c2cfa-4ad8-4af7-a4b7-a358c2e69f1a) |

- also update the key in merge pipeline so that it can utilize the cache create from the pull_request pipeline

## Changes made:

-

## Test Scope / Change impact:

-

## Issue

- TODO: delete the cache in certain branch after merge
