### PR TITLE
fix: Adjusted modal style

### DIFF
--- a/shared/components/Modalow/Body.tsx
+++ b/shared/components/Modalow/Body.tsx
@@ -12,7 +12,7 @@ const InternalBody: ForwardRefRenderFunction<HTMLDivElement, BodyProps> = (
 
   const dialogContentClassName = cn(
     "modal__container__dialog__content",
-    "flex px-8 py-3 text-white flex-auto"
+    "px-8 py-3 text-white"
   );
 
   return (

--- a/shared/components/Modalow/Modalow.tsx
+++ b/shared/components/Modalow/Modalow.tsx
@@ -76,7 +76,7 @@ const InternalModal: ForwardRefRenderFunction<HTMLDivElement, ModalProps> = (
     "modal__container",
     fullScreen
       ? "fixed z-20 top-0 left-0"
-      : "fixed z-20 left-1/2 transform -translate-x-1/2"
+      : "fixed z-20 top-1/2 left-1/2 transform -translate-x-1/2  -translate-y-1/2"
   );
 
   const dialogClassName = cn(


### PR DESCRIPTION
## Why need this change? / Root cause:

- Body.tsx 中 dialogContentClassName 誤加了 flex flex-auto class 導致 children 樣式異常。
- Modalow.tsx 未遵循設計稿 Dialog 位置。


| Before | After |
|-----|-------|
| <img width="415" alt="image" src="https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/23444218/a79b4020-0158-45dc-89a0-cb960fd135ce">| <img width="416" alt="image" src="https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/23444218/eaa74890-1df5-4188-8ff4-fa7d465e158b"> |

## Changes made:

- 將Body.tsx 內 dialogContentClassName 中的 flex flex-auto 移除。
- 對 Modalow.tsx 內的 dialogContainerClassName 增加了 top-1/2 -translate-y-1/2 class 已符合樣式。

## Test Scope / Change impact:

-

## Issue

- #85 
