### PR TITLE
feat: current user info & mock example

### DIFF
--- a/mocks/auth.ts
+++ b/mocks/auth.ts
@@ -1,0 +1,14 @@
+import { User } from "@/requests/auth/user";
+
+export const mock_loginEndpoint = "/auth/login";
+
+export const mock_loginToken = "login-token";
+
+export const mock_refreshToken = () =>
+  `refresh-token-${Math.floor(Math.random() * (100 - 1) + 1)}`;
+
+export const mock_user: User = {
+  uid: "mock_uid",
+  name: "mock user",
+  email: "mock@google.com",
+};

--- a/pages/api/mock/auth/login.ts
+++ b/pages/api/mock/auth/login.ts
@@ -1,9 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { mock_loginEndpoint } from "@/mocks/auth";
+
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === "GET") {
     return res.json({
-      url: "/auth/login",
+      url: mock_loginEndpoint,
     });
   }
 

--- a/pages/api/mock/auth/token.ts
+++ b/pages/api/mock/auth/token.ts
@@ -1,9 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { mock_loginToken } from "@/mocks/auth";
+
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === "POST") {
     return res.json({
-      token: "init_jwt_token",
+      token: mock_loginToken,
     });
   }
 

--- a/pages/api/mock/user/me.ts
+++ b/pages/api/mock/user/me.ts
@@ -1,12 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { mock_refreshToken } from "@/mocks/auth";
+import { mock_user } from "@/mocks/auth";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method === "POST") {
-    return res.json({
-      token: mock_refreshToken(),
-    });
+  if (req.method === "GET") {
+    return res.json(mock_user);
   }
 
   throw new Error("Invalid method!");

--- a/requests/auth/auth.ts
+++ b/requests/auth/auth.ts
@@ -8,24 +8,38 @@ export enum LoginType {
 }
 
 export const getLoginEndpoint = (
-  data: LoginType
+  type: LoginType
 ): IRequestWrapper<{ url: string }> => {
-  return requestWrapper({
-    url: `/api/internal/auth/login?type=${data}`,
-    method: "GET",
-  });
+  return requestWrapper(
+    {
+      url: "/api/internal/auth/login",
+      method: "GET",
+      params: { type },
+    },
+    {
+      isPublic: true,
+    }
+  );
 };
 
 export const getMockToken = (): IRequestWrapper<{ token: string }> => {
-  return requestWrapper({
-    url: `/api/internal/auth/token`,
-    method: "POST",
-  });
+  return requestWrapper(
+    {
+      url: `/api/internal/auth/token`,
+      method: "POST",
+    },
+    {
+      isPublic: true,
+    }
+  );
 };
 
-export const authentication = (): IRequestWrapper<{ token: string }> => {
+export const authentication = (
+  token: string
+): IRequestWrapper<{ token: string }> => {
   return requestWrapper({
     url: `/api/internal/auth/authentication`,
     method: "POST",
+    data: { token },
   });
 };

--- a/requests/auth/user.ts
+++ b/requests/auth/user.ts
@@ -1,0 +1,14 @@
+import { IRequestWrapper, requestWrapper } from "../request";
+
+export interface User {
+  uid: string;
+  name: string;
+  email: string;
+}
+
+export const getCurrentUser = (): IRequestWrapper<User> => {
+  return requestWrapper({
+    url: `/api/internal/user/me`,
+    method: "GET",
+  });
+};

--- a/shared/containers/provider/AuthProvider.tsx
+++ b/shared/containers/provider/AuthProvider.tsx
@@ -1,3 +1,4 @@
+import { User } from "@/requests/auth/user";
 import AuthContext from "@/shared/contexts/AuthContext";
 import { FC, ReactNode, useState } from "react";
 
@@ -7,12 +8,16 @@ type Props = {
 
 const AuthProvider: FC<Props> = ({ children }) => {
   const [token, setToken] = useState<string | null | undefined>();
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
 
   return (
     <AuthContext.Provider
       value={{
         token,
         setToken: (token: string | undefined | null) => setToken(token),
+        currentUser,
+        setCurrentUser: (currentUser: User | null) =>
+          setCurrentUser(currentUser),
       }}
     >
       {children}

--- a/shared/contexts/AuthContext.tsx
+++ b/shared/contexts/AuthContext.tsx
@@ -1,13 +1,18 @@
+import { User } from "@/requests/auth/user";
 import { createContext } from "react";
 
 interface IAuthContext {
   token: string | null | undefined;
   setToken: (token: string | null | undefined) => unknown;
+  currentUser: User | null;
+  setCurrentUser: (user: User | null) => unknown;
 }
 
 const AuthContext = createContext<IAuthContext>({
   token: undefined,
   setToken: () => null,
+  currentUser: null,
+  setCurrentUser: () => null,
 });
 
 export default AuthContext;

--- a/shared/hooks/useRequest.ts
+++ b/shared/hooks/useRequest.ts
@@ -1,27 +1,30 @@
-import { useMemo } from "react"
-import { AxiosRequestConfig } from "axios"
+import { useMemo } from "react";
+import { AxiosRequestConfig } from "axios";
 
-import { IRequestWrapper } from "@/requests/request"
-import useAxios from "./context/useAxios"
+import { IRequestWrapper } from "@/requests/request";
+import useAxios from "./context/useAxios";
+import useAuth from "./context/useAuth";
 
 const useRequest = () => {
-  const { axios } = useAxios()
+  const { axios } = useAxios();
+  const { token } = useAuth();
 
   const fetch = useMemo(
     () =>
       <T>(requestWrapper: IRequestWrapper<T>) => {
-        const additionalToRequest: AxiosRequestConfig = {}
+        const additionalToRequest: AxiosRequestConfig = {};
+
         if (!requestWrapper.additional?.isPublic) {
-          //   additionalToRequest.headers = { Authorization: `Bearer ${jwtToken}` };
+          additionalToRequest.headers = { Authorization: `Bearer ${token}` };
         }
         return requestWrapper
           .executor(axios, additionalToRequest)
-          .then((res) => res.data)
+          .then((res) => res.data);
       },
-    [axios]
-  )
+    [axios, token]
+  );
 
-  return { fetch }
-}
+  return { fetch };
+};
 
-export default useRequest
+export default useRequest;

--- a/shared/hooks/useUser.ts
+++ b/shared/hooks/useUser.ts
@@ -1,3 +1,4 @@
+import { getCurrentUser as getCurrentUserReq } from "@/requests/auth/user";
 import {
   LoginType,
   getLoginEndpoint as getLoginEndpointReq,
@@ -21,8 +22,8 @@ const useUser = () => {
     return await fetch(getMockTokenReq());
   };
 
-  const authentication = async () => {
-    return await fetch(authenticationReq());
+  const authentication = async (token: string) => {
+    return await fetch(authenticationReq(token));
   };
 
   const login = (token: string) => {
@@ -45,6 +46,10 @@ const useUser = () => {
     }
   };
 
+  const getCurrentUser = async () => {
+    return await fetch(getCurrentUserReq());
+  };
+
   return {
     getLoginEndpoint,
     getMockToken,
@@ -53,6 +58,7 @@ const useUser = () => {
     logout,
     getTokenInCookie,
     updateTokenInCookie,
+    getCurrentUser,
   };
 };
 


### PR DESCRIPTION
## Why need this change? / Root cause:

- mock example: `mocks` folder set mock data provide to mock api route
- get current user info by header bearer token

## Changes made:

-

## Test Scope / Change impact:

-

## Issue

-
