### PR TITLE
fix: add deploy job timeout

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -14,6 +14,7 @@ jobs:
     name: Build and Test and Deploy to AWS EC2
     runs-on: ubuntu-latest
     environment: production
+    timeout-minutes: 5
 
     steps:
       - name: Git checkout


### PR DESCRIPTION
## Why need this change? / Root cause:

- The current workflow of deployment sometimes gets stuck, which consequently causes other jobs to be queued.

![image](https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/45290853/f2f843a1-8cf1-4618-b990-920dcb630597)


## Changes made:

- add [job timeout](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) 


## Test Scope / Change impact:

-

## Issue

-
