### PR TITLE
fix: only install prod deps in ec2

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -58,7 +58,7 @@ jobs:
           key: ${{ secrets.EC2_KEY }}
           script: |
             cd ${{ env.APPLICATION_FOLDER }}
-            yarn install --frozen-lockfile
+            yarn install --production --frozen-lockfile
 
       - name: Start the app on EC2
         uses: appleboy/ssh-action@master


### PR DESCRIPTION
## Why need this change? / Root cause:

- EC2 install too many deps, so it frequently install until timeout

## Changes made:

- Use `--production` flag to only install production dependencies, and neglect devDependencies

## Test Scope / Change impact:

-

## Issue

-
