### PR TITLE
fix: some password input issues in create room

### DIFF
--- a/components/lobby/CreateRoomModal/GameListModal/GameList/GameItem.tsx
+++ b/components/lobby/CreateRoomModal/GameListModal/GameList/GameItem.tsx
@@ -9,7 +9,7 @@ interface GameItemProp {
 
 function GameItem({ game, onChange, checked }: GameItemProp) {
   return (
-    <li className="">
+    <li>
       <input
         type="radio"
         className={`hidden ${styles.gamePickRadio}`}

--- a/requests/rooms/index.ts
+++ b/requests/rooms/index.ts
@@ -1,9 +1,9 @@
 import { IRequestWrapper, requestWrapper } from "@/requests/request";
 
-export type CreateRoomDataType = {
+export type CreateRoomFormType = {
   name: string;
   gameId: string;
-  password: number | null | "";
+  password: null | string;
   minPlayers: number;
   maxPlayers: number;
 };
@@ -69,7 +69,7 @@ export namespace RoomInfo {
 }
 
 export const createRoomEndpoint = (
-  data: CreateRoomDataType
+  data: CreateRoomFormType
 ): IRequestWrapper<Room> => {
   return requestWrapper({
     url: "/api/internal/rooms",


### PR DESCRIPTION
## Why need this change? / Root cause:

- Using `handlePasswordKeyUp` and `handlePasswordChange` simultaneously caused potential repeated input. 

As shown in the following GIF:

| Before | After |
|-----|-------|
|![before](https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/23444218/16a1dce6-adee-4457-b1d0-e042a49664a4)|![after](https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/23444218/a78152ae-093f-41db-bd84-65436f3ae1a6)|

## Changes made:
- feat: optimized the UX of password input in the private room field.
- fix: fixed the issue that it would submit 3 digits when the password type is number.
- fix: removed the potential for repeated input of the password.
- refactor: added more handlers in the handlePasswordKeyUp function.
- style: added a `div` to wrap input fields to avoid the error message being flex between input.

## Test Scope / Change impact:

-

## Issue

- #101 
- #135 
