### PR TITLE
✅refactor: rooms

### DIFF
--- a/components/shared/Tabs/Tab.tsx
+++ b/components/shared/Tabs/Tab.tsx
@@ -1,10 +1,10 @@
-import { Key } from "react";
 import { cn } from "@/lib/utils";
-export interface TabProps {
+import { Key } from "react";
+export interface TabProps<T extends Key = string> {
   /**
    * The key of tab
    */
-  tabKey: Key;
+  tabKey: T;
   /**
    * The label of tab
    */
@@ -21,10 +21,10 @@ export interface TabProps {
   /**
    * Callback executed when tab is clicked
    */
-  onTabClick?: (tabKey: Key) => void;
+  onTabClick?: (tabKey: T) => void;
 }
 
-export default function Tab(props: TabProps) {
+export default function Tab<T extends Key = string>(props: TabProps<T>) {
   const { tabKey, label, className, active, onTabClick } = props;
 
   const tabBaseClass = ` w-fit py-3 text-center text-base text-white relative  after:content-'' after:w-full after:h-[4px] after:block after:absolute after:bottom-0 after:left-0  after:transition-colors hover:after:bg-[#2F88FF]`;

--- a/components/shared/Tabs/Tabs.stories.tsx
+++ b/components/shared/Tabs/Tabs.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import Tabs, { TabsProps } from ".";
+import Tabs, { TabsProps, TabItemType } from ".";
 
 const meta: Meta<typeof Tabs> = {
   title: "Navigation/Tabs",
@@ -8,7 +8,7 @@ const meta: Meta<typeof Tabs> = {
 };
 
 export default meta;
-type Story = StoryObj<TabsProps>;
+type Story = StoryObj<TabsProps<number>>;
 
 export const Playground: Story = {
   args: {

--- a/components/shared/Tabs/Tabs.tsx
+++ b/components/shared/Tabs/Tabs.tsx
@@ -1,22 +1,22 @@
 import { useState, Key, ReactNode } from "react";
 import Tab from "./Tab";
 import { cn } from "@/lib/utils";
-export interface TabItemType {
-  key: Key;
+export interface TabItemType<T extends Key = string> {
+  key: T;
   label?: string;
 }
 
 export type TabSizeType = "default" | "large";
 
-export interface TabsProps {
+export interface TabsProps<T extends Key = string> {
   /**
    * The array of tabItem to render tabBar
    */
-  tabs: TabItemType[];
+  tabs: TabItemType<T>[];
   /**
    * Initial active tab's key
    */
-  defaultActiveKey?: Key;
+  defaultActiveKey?: T;
   /**
    * The className of tabs that wraps tabBar and tabPane
    */
@@ -44,14 +44,14 @@ export interface TabsProps {
   /**
    * Function that recieved activeTabItem and render content of tabPane
    */
-  renderTabPaneContent?: (tabItem: TabItemType) => ReactNode;
+  renderTabPaneContent?: (tabItem: TabItemType<T>) => ReactNode;
   /**
    * Callback executed when tab is clicked
    */
-  onChange?: (tabKey: Key) => void;
+  onChange?: (tabKey: T) => void;
 }
 
-export default function Tabs(props: TabsProps) {
+export default function Tabs<T extends Key = string>(props: TabsProps<T>) {
   const {
     tabs,
     defaultActiveKey,
@@ -78,7 +78,7 @@ export default function Tabs(props: TabsProps) {
 
   const tabClass = cn(isLageSize ? "px-3" : "px-0", customTabClass);
 
-  function handleChangeActiveTab(nextTabkey: Key) {
+  function handleChangeActiveTab(nextTabkey: T) {
     if (nextTabkey === activeKey) return;
     setActiveKey(nextTabkey);
     onChange && onChange(nextTabkey);

--- a/containers/room/RoomListView.tsx
+++ b/containers/room/RoomListView.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useState } from "react";
 import { Room, RoomType, getRooms } from "@/requests/rooms";
 import useRequest from "@/hooks/useRequest";
 import usePagination from "@/hooks/usePagination";
@@ -11,7 +11,6 @@ type Props = {
   status: RoomType;
 };
 const RoomsListView: FC<Props> = ({ status }) => {
-  const [roomStatus, setRoomStatus] = useState<RoomType>(status);
   const { fetch } = useRequest();
   const {
     nextPage,
@@ -23,7 +22,7 @@ const RoomsListView: FC<Props> = ({ status }) => {
     errorMessage,
   } = usePagination({
     source: (page: number, perPage: number) =>
-      fetch(getRooms({ page, perPage, status: roomStatus })),
+      fetch(getRooms({ page, perPage, status })),
     defaultPerPage: 20,
   });
   const [selectedRoom, setSelectedRoom] = useState<Room | undefined>();
@@ -39,10 +38,6 @@ const RoomsListView: FC<Props> = ({ status }) => {
   const backPerPage = () => {
     setPerPage(-10);
   };
-
-  useEffect(() => {
-    setRoomStatus(status);
-  }, [status]);
 
   const Pagination = () => {
     return (

--- a/pages/rooms.tsx
+++ b/pages/rooms.tsx
@@ -1,40 +1,28 @@
-import { ReactElement, useState } from "react";
+import { ReactElement } from "react";
 import { RoomType } from "@/requests/rooms";
 import RoomsListView from "@/containers/room/RoomListView";
 import Tabs from "@/components/shared/Tabs";
 
 const tabs = [
   {
-    key: RoomType.WAITING as string,
+    key: RoomType.WAITING,
     label: "正在等待玩家配對",
   },
   {
-    key: RoomType.PLAYING as string,
+    key: RoomType.PLAYING,
     label: "遊戲已開始",
   },
 ];
 const Rooms = () => {
-  const [currentTab, setCurrentTab] = useState<RoomType>(RoomType.WAITING);
-
   return (
     <div className="bg-dark29 rounded-[10px] py-5 px-6 m-4 h-full">
       <Tabs
         tabs={tabs}
         defaultActiveKey={RoomType.WAITING}
         size="large"
-        onChange={(key) => setCurrentTab(key as RoomType)}
-        renderTabPaneContent={() => {
-          return (
-            <>
-              {currentTab === RoomType.WAITING && (
-                <RoomsListView status={currentTab} />
-              )}
-              {currentTab === RoomType.PLAYING && (
-                <RoomsListView status={currentTab} />
-              )}
-            </>
-          );
-        }}
+        renderTabPaneContent={(currentTab) => (
+          <RoomsListView status={currentTab.key} key={currentTab.key} />
+        )}
       />
     </div>
   );


### PR DESCRIPTION
## Why need this change? / Root cause:

- Simplify code for room list switching using Tabs component

## Changes made:

- Update key type of Tabs component to be generic
- Remove unnecessary useEffect and useState syntax

## Test Scope / Change impact:

- Manual testing only.

## Issue

- #127 

## 補充說明

 `RoomListView` 是一個會接收 props 有 status 屬性的元件，當元件錨定時，會透過 usePagination hook 將 status 作為參數向後端拿取房間列表。

在原本的寫法中， `RoomListView` 會使用 useState 建立一組初始值為 props.status 的狀態，並使用 useEffect 監聽 props.status ，當 props.status 有變化時，則呼叫 setState 改變前述建立的 status 狀態，重點程式碼如下：

```
const RoomsListView: FC<Props> = ({ status }) => {
  const [roomStatus, setRoomStatus] = useState<RoomType>(status);
　...
  useEffect(() => {
    setRoomStatus(status);
  }, [status]);
　...
}

```

上述程式碼個人有兩個想法，以下說明：
1.  依照現行需求，使用上述程式碼的目的，猜測是為了希望當 props.status 的值有變換時，要重新依據新的 status 執行 API 以取得不同狀態的房間列表，但這樣的寫法是無效且不必要的，原因以下說明：

 　(1) 無效的原因是，元件將 status 作為參數給 usePagination 後，usePagination 裡面負責呼叫 API 的 useEffect 裡，只有 page 與 perPage 參數被加入依賴陣列，因此雖然 status 改變後，`RoomsListView` 會觸發 **Update**，但除非傳給 usePagination 的 page 與 perPage 有改變，不然 usePagination  不會重複執行它的 useEffect 。

　 (2) 不必要的原因是，在父元件 `Rooms` 的 JSX 中，已經使用條件式渲染`RoomsListView`元件，節錄程式碼如下：
```
            <>
              {currentTab === RoomType.WAITING && (
                <RoomsListView status={currentTab} />
              )}
              {currentTab === RoomType.PLAYING && (
                <RoomsListView status={currentTab} />
              )}
            </>
```
因此當父元件的 currentTab 狀態改變時，`RoomsListView`元件重新 **Mounted**，因此會重新調用一個**新的** usePagination，所以會呼叫 API，因此元件內部有沒有定義一組 useState 與 useEffect 的狀態都不影響結果。

2. 第二個想法是，「將 props 重新定義為一組相同的狀態，並透過 useEffect 監聽該 props 的變化，若有變化則觸發 setState 改變成新 props 一模一樣的狀態』的實作方法，可能是官方不建議的寫法 ( 前提是沒有額外的邏輯會使用該 state )，而官方針對此情形所建議的寫法，就是上述的第 2 點 （從父元件進行條件式渲染），只不過是使用 key 屬性，而非使用多組的 `===` 判斷式，大概是像以下這樣子：
`<RoomsListView status={currentTab.key} key={currentTab.key} />`
（[官方參考連結](https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes)）

基於上述說明，我將相關程式碼修改成官方建議的方式，並發送此 PR，同時修改的過程中發現以前在寫 Tabs 元件時，把 tabKey 的型別指定為 Key 型別，無法跟現行程式碼合併，因此也同步將該型別調整為泛型，並放在第一個 commit 裡。

以上說明，如有誤再麻煩告知，感謝！