### PR TITLE
refactor: redefine CI workflow steps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI workflow
 
 concurrency: 
-  group: ${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
 
-  build:
+  build-and-lhci:
     runs-on: ubuntu-latest
     needs: init
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
   build-and-lhci:
+    name: Build
     runs-on: ubuntu-latest
     needs: init
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   init:
+    name: Initial Common Steps
     runs-on: ubuntu-latest
 
     steps:
@@ -36,7 +37,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
   build-and-lhci:
-    name: Build
+    name: Build And LHCI
     runs-on: ubuntu-latest
     needs: init
 
@@ -86,6 +87,7 @@ jobs:
         run: node ./scripts/lhciScanReporter.js
   
   test:
+    name: Test
     runs-on: ubuntu-latest
     needs: init
 
@@ -110,6 +112,7 @@ jobs:
         run: yarn test
 
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     needs: init
 
@@ -134,6 +137,7 @@ jobs:
         run: npx eslint@7.32.0 --no-error-on-unmatched-pattern -c .eslintrc.json $(git diff --name-only --relative --diff-filter=ACMRTUXB HEAD~1 | grep  -E ".(js|jsx|ts|tsx)$")
   
   knip-scan:
+    name: Knip Scan
     runs-on: ubuntu-latest
     needs: init
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,29 @@ env:
   NEXT_PUBLIC_CI_MODE: true
 
 jobs:
-  build:
-    name: Build
+  init:
     runs-on: ubuntu-latest
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+
+      - name: Cache dependencies
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            ~/.cache/Cypress
+          key: deps-node-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+
+  build:
+    runs-on: ubuntu-latest
+    needs: init
 
     steps:
       - name: Git checkout
@@ -39,12 +59,6 @@ jobs:
       - name: Build
         run: yarn build
 
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: PR-${{ github.event.pull_request.number }}-build-artifacts
-          path: ${{ github.workspace }}/.next
-
       - name: Bundle Watch
         shell: bash
         env: 
@@ -55,10 +69,24 @@ jobs:
           CI_COMMIT_SHA: ${{ github.sha }}
           BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
         run: yarn run bundlewatch
+
+      - name: Audit URLs using Lighthouse
+        uses: treosh/lighthouse-ci-action@v10
+        with:
+          uploadArtifacts: false
+          temporaryPublicStorage: true
+          configPath: ./lighthouserc.js
+        env:
+          LHCI_GITHUB_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+
+      - name: lhci PR reporter
+        env: 
+          GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+        run: node ./scripts/lhciScanReporter.js
   
   test:
     runs-on: ubuntu-latest
-    needs: build
+    needs: init
 
     steps:
       - name: Git checkout
@@ -82,7 +110,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    needs: build
+    needs: init
 
     steps:
       - name: Git checkout
@@ -106,7 +134,7 @@ jobs:
   
   knip-scan:
     runs-on: ubuntu-latest
-    needs: build
+    needs: init
 
     steps:
       - name: Git checkout
@@ -131,44 +159,3 @@ jobs:
         run: |
           yarn run knip > knipScanResult.txt 2>&1
           node ./scripts/knipScanReporter.js
-
-  lhci-scan:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v3
-
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            node_modules
-            ~/.cache/Cypress
-          key: deps-node-modules-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: PR-${{ github.event.pull_request.number }}-build-artifacts
-          path: .next
-
-      - name: Audit URLs using Lighthouse
-        uses: treosh/lighthouse-ci-action@v10
-        with:
-          uploadArtifacts: false
-          temporaryPublicStorage: true
-          configPath: ./lighthouserc.js
-        env:
-          LHCI_GITHUB_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
-
-      - name: lhci PR reporter
-        env: 
-          GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
-        run: node ./scripts/lhciScanReporter.js


### PR DESCRIPTION
## Why need this change? / Root cause:

- for now, I find that the CI workflow take too long to execute, it is because upload & download `artifact`  take too much time
- I extract a `init` step to handle downloading & caching  of dependencies, and add `lhci` scan directly in `build` step.

| Old Version (⏰ Time spent: about 8 mins - 10 mins) | New Version (⏰ Time spent: about 3 mins) |
|-----|-------|
| ![圖片](https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/35811214/78db5482-f04c-4906-b9a7-076e6fcd15a2) | ![圖片](https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/35811214/b2e8f135-027d-43ae-8171-c55bc732a7ff) |


## Changes made:

-

## Test Scope / Change impact:

-

## Issue

-
