### PR TITLE
fix/private selected

### DIFF
--- a/components/lobby/CreateRoomModal/CreateRoomModal.tsx
+++ b/components/lobby/CreateRoomModal/CreateRoomModal.tsx
@@ -95,8 +95,8 @@ export default function CreateRoomModal() {
     setshowThisModal(false);
   }
 
-  function getPasswordSelected(bool: boolean) {
-    setIsPublic(!bool);
+  function getPasswordSelected(e: React.MouseEvent<HTMLElement>) {
+    setIsPublic(false);
   }
 
   return (
@@ -239,7 +239,7 @@ export default function CreateRoomModal() {
                       subTitle={"請輸入此房間密碼"}
                       passwordValues={passwordValues}
                       setPasswordValues={setPasswordValues}
-                      getPasswordSelected={getPasswordSelected}
+                      onInputClick={getPasswordSelected}
                     />
                   </label>
                 </div>

--- a/components/lobby/CreateRoomModal/CreateRoomModal.tsx
+++ b/components/lobby/CreateRoomModal/CreateRoomModal.tsx
@@ -95,6 +95,10 @@ export default function CreateRoomModal() {
     setshowThisModal(false);
   }
 
+  function getPasswordSelected(bool: boolean) {
+    setIsPublic(!bool);
+  }
+
   return (
     <>
       <Button onClick={() => setshowThisModal(true)}>開創房間</Button>
@@ -235,6 +239,7 @@ export default function CreateRoomModal() {
                       subTitle={"請輸入此房間密碼"}
                       passwordValues={passwordValues}
                       setPasswordValues={setPasswordValues}
+                      getPasswordSelected={getPasswordSelected}
                     />
                   </label>
                 </div>

--- a/components/shared/PasswordField/PasswordField.tsx
+++ b/components/shared/PasswordField/PasswordField.tsx
@@ -8,7 +8,7 @@ type PasswordFieldProps = {
   passwordValues: string[];
   disabled?: boolean;
   setPasswordValues: (values: string[]) => void;
-  getPasswordSelected?: (bool: boolean) => void;
+  onInputClick?: (e: React.MouseEvent<HTMLElement>) => void;
 };
 
 const PasswordField: FC<PasswordFieldProps> = ({
@@ -18,7 +18,7 @@ const PasswordField: FC<PasswordFieldProps> = ({
   passwordValues,
   disabled,
   setPasswordValues,
-  getPasswordSelected,
+  onInputClick,
 }) => {
   const passwordRefs = useRef<(HTMLInputElement | null)[]>([]);
 
@@ -103,7 +103,7 @@ const PasswordField: FC<PasswordFieldProps> = ({
               onKeyUp={(e) => handlePasswordKeyUp(e, index)}
               onClick={(event) => {
                 event.stopPropagation(); // 防止冒泡到父層的onClick
-                getPasswordSelected && getPasswordSelected(true);
+                onInputClick && onInputClick(event);
               }}
               disabled={disabled}
               data-testid={`input-password-${index}`}

--- a/components/shared/PasswordField/PasswordField.tsx
+++ b/components/shared/PasswordField/PasswordField.tsx
@@ -8,6 +8,7 @@ type PasswordFieldProps = {
   passwordValues: string[];
   disabled?: boolean;
   setPasswordValues: (values: string[]) => void;
+  getPasswordSelected?: (bool: boolean) => void;
 };
 
 const PasswordField: FC<PasswordFieldProps> = ({
@@ -17,6 +18,7 @@ const PasswordField: FC<PasswordFieldProps> = ({
   passwordValues,
   disabled,
   setPasswordValues,
+  getPasswordSelected,
 }) => {
   const passwordRefs = useRef<(HTMLInputElement | null)[]>([]);
 
@@ -99,7 +101,10 @@ const PasswordField: FC<PasswordFieldProps> = ({
               value={password}
               maxLengthClassName="hidden"
               onKeyUp={(e) => handlePasswordKeyUp(e, index)}
-              onClick={(event) => event.stopPropagation()} // 防止冒泡到父層的onClick
+              onClick={(event) => {
+                event.stopPropagation(); // 防止冒泡到父層的onClick
+                getPasswordSelected && getPasswordSelected(true);
+              }}
               disabled={disabled}
               data-testid={`input-password-${index}`}
             />


### PR DESCRIPTION
## Why need this change? / Root cause:

- Clicking the password when creating a room should select the private room immediately

## Changes made:
component:

- PasswordField 
- CreateRoomModal

## Test Scope / Change impact:

-

## Issue

- #230 
