### PR TITLE
:bug: fix(auth): tmp rm authentication

### DIFF
--- a/containers/util/Startup.tsx
+++ b/containers/util/Startup.tsx
@@ -24,10 +24,13 @@ const Startup: FC<Props> = ({ children, isAnonymous }) => {
     async function fetch() {
       const jwt = getTokenInCookie();
       if (jwt) {
-        const res = await authentication(jwt);
-        if (res.token) {
-          setToken(res.token);
-        }
+        setToken(jwt);
+        // The `authentication` is needed when the token is expired
+        // TODO: Put it back after clarify the refresh workflow
+        // const res = await authentication(jwt);
+        // if (res.token) {
+        //   setToken(res.token);
+        // }
       } else {
         setToken(null);
       }


### PR DESCRIPTION
## Why need this change? / Root cause:

- Because of the api protected the `authentication`(require Bearer token), it cause error after login.
- The authentication is POSTed every time we refresh, but we still haven't clarified the refresh workflow.
- We should understand why authentication exists, when we need to request it, and how to handle the data after receiving the response.

## Changes made:

- temporarily remove the authentication POST request.

## Test Scope / Change impact:

-

## Issue

-
