### PR TITLE
refactor: socket.io infra and decouple ws and chatroom

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "i18n-ally.localesPaths": ["public/locales"]
+}

--- a/components/rooms/RoomChatroom/RoomChatroom.tsx
+++ b/components/rooms/RoomChatroom/RoomChatroom.tsx
@@ -3,6 +3,7 @@ import Button from "@/components/shared/Button";
 import ChatMessage from "./ChatMessage";
 import { MessageType } from ".";
 import useChatroom from "@/hooks/context/useChatroom";
+import useSocketCore from "@/hooks/context/useSocketCore";
 
 type RoomChatroom = {
   roomId: string;
@@ -14,8 +15,9 @@ export default function RoomChatroom({ roomId }: RoomChatroom) {
     sendChatMessage,
     joinChatroom,
     leaveChatroom,
-    readyState,
+    // readyState,
   } = useChatroom();
+  const { socket } = useSocketCore();
   const scrollbarRef = useRef<HTMLDivElement | null>(null);
   const [inputValue, setInputValue] = useState<string>("");
   const [messageList, setMessageList] = useState<MessageType[]>([]);
@@ -23,11 +25,10 @@ export default function RoomChatroom({ roomId }: RoomChatroom) {
   // join chatroom by roomId
   useEffect(() => {
     if (!roomId) return;
-    if (readyState < 1) return;
+    if (!socket || !socket.connected) return;
     joinChatroom(roomId);
-
     return () => leaveChatroom(roomId);
-  }, [joinChatroom, leaveChatroom, roomId, readyState]);
+  }, [joinChatroom, leaveChatroom, roomId, socket]);
 
   // update message list while received new message from websocket
   useEffect(() => {

--- a/containers/provider/ChatroomProvider.tsx
+++ b/containers/provider/ChatroomProvider.tsx
@@ -1,107 +1,43 @@
 import ChatroomContext from "@/contexts/ChatroomContext";
-import {
-  PropsWithChildren,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { PropsWithChildren, useCallback, useEffect, useState } from "react";
 import { MessageType } from "@/components/rooms/RoomChatroom";
 import useAuth from "@/hooks/context/useAuth";
+import useSocketCore from "@/hooks/context/useSocketCore";
+import { SOCKET_EVENT } from "@/contexts/SocketContext";
 
 export type ChatroomContextType = ReturnType<typeof useChatroomCore>;
 
-enum SOCKET_EVENT {
-  CONNECTION_OPEN = "CONNECTION_OPEN",
-  CONNECTION_CLOSE = "CONNECTION_CLOSE",
-  CHATROOM_JOIN = "CHATROOM_JOIN",
-  CHATROOM_LEAVE = "CHATROOM_LEAVE",
-  CHAT_MESSAGE = "CHAT_MESSAGE",
-}
-
-enum WS_ReadyState {
-  CONNECTING = 0,
-  OPEN,
-  CLOSED,
-}
-
-export type Socket_DispatchActionType = {
-  type: keyof typeof SOCKET_EVENT;
-  payload: Record<string, any>;
-};
-
 function useChatroomCore() {
+  const { socket } = useSocketCore();
   const { currentUser } = useAuth();
-  const webSocket = useRef<WebSocket | null>(null);
   const [lastMessage, setLastMessage] = useState<MessageType | undefined>(
     undefined
   );
-  const [readyState, setReadyState] = useState<WS_ReadyState>(0);
 
   /**
    * Dispatches a socket event to the server.
    * @param {string} action.type - The type of the socket event.
    * @param {any} action.payload - The payload of the socket event.
    */
-  function dispatchSocketEvent(action: Socket_DispatchActionType): void {
-    webSocket.current?.send(JSON.stringify(action));
-  }
-
-  // TODO delete the next useEffect: this is only for mock socket server
-  useEffect(() => {
-    fetch("/api/internal/socket");
-  }, []);
 
   useEffect(() => {
     if (!currentUser) return;
 
-    const user = {
-      id: currentUser.id,
-      nickname: currentUser.nickname,
-    };
+    // const user = {
+    //   id: currentUser.id,
+    //   nickname: currentUser.nickname,
+    // };
 
-    // TODO switch to correct url
-    webSocket.current = new WebSocket("ws://localhost:3000");
+    socket?.on(SOCKET_EVENT.CHAT_MESSAGE, (data: any) => {
+      // eslint-disable-next-line no-console
+      console.log("Message received in chatroom context", data);
+      setLastMessage(data);
+    });
 
-    const ws = webSocket.current;
-
-    // trigger when connected, notify server to regist user
-    ws.onopen = () => {
-      setReadyState(1);
-      dispatchSocketEvent({
-        type: SOCKET_EVENT.CONNECTION_OPEN,
-        payload: { user },
-      });
-    };
-
-    // trigger when received any message
-    ws.onmessage = (event: MessageEvent) => {
-      const data = JSON.parse(event.data) as any;
-      if (data?.type === SOCKET_EVENT.CHAT_MESSAGE) {
-        setLastMessage(data.payload);
-      }
-    };
-
-    // trigger when server shotdown
-    ws.onclose = () => {
-      setReadyState(2);
-      setLastMessage({
-        from: "SYSTEM",
-        content: "聊天室伺服器已關閉",
-        timestamp: new Date().toISOString(),
-        to: "ALL",
-      });
-    };
-
-    // clean up: notify the server to handle user disconnected
     return () => {
-      dispatchSocketEvent({
-        type: SOCKET_EVENT.CONNECTION_CLOSE,
-        payload: user,
-      });
-      ws.close();
+      socket?.off(SOCKET_EVENT.CHAT_MESSAGE);
     };
-  }, [currentUser]);
+  }, [currentUser, socket]);
 
   /**
    * Sends a chat message to the server.
@@ -110,8 +46,7 @@ function useChatroomCore() {
    */
   const sendChatMessage = useCallback(
     (message: Pick<MessageType, "content" | "to">) => {
-      if (!currentUser || !webSocket.current) return;
-
+      if (!currentUser) return;
       const payload: MessageType = {
         from: "USER",
         user: { id: currentUser.id, nickname: currentUser.nickname },
@@ -119,43 +54,37 @@ function useChatroomCore() {
         ...message,
       };
 
-      dispatchSocketEvent({ type: SOCKET_EVENT.CHAT_MESSAGE, payload });
+      socket?.emit(SOCKET_EVENT.CHAT_MESSAGE, payload);
     },
-    [currentUser]
+    [currentUser, socket]
   );
 
   const joinChatroom = useCallback(
     (chatroomId: string) => {
       if (!currentUser) return;
-      dispatchSocketEvent({
-        type: SOCKET_EVENT.CHATROOM_JOIN,
-        payload: {
-          user: {
-            id: currentUser.id,
-            nickname: currentUser.nickname,
-          },
-          chatroomId,
+      socket?.emit(SOCKET_EVENT.CHATROOM_JOIN, {
+        user: {
+          id: currentUser.id,
+          nickname: currentUser.nickname,
         },
+        chatroomId,
       });
     },
-    [currentUser]
+    [currentUser, socket]
   );
 
   const leaveChatroom = useCallback(
     (chatroomId: string) => {
       if (!currentUser) return;
-      dispatchSocketEvent({
-        type: SOCKET_EVENT.CHATROOM_LEAVE,
-        payload: {
-          user: {
-            id: currentUser.id,
-            nickname: currentUser.nickname,
-          },
-          chatroomId,
+      socket?.emit(SOCKET_EVENT.CHATROOM_LEAVE, {
+        user: {
+          id: currentUser.id,
+          nickname: currentUser.nickname,
         },
+        chatroomId,
       });
     },
-    [currentUser]
+    [currentUser, socket]
   );
 
   return {
@@ -163,7 +92,6 @@ function useChatroomCore() {
     sendChatMessage,
     joinChatroom,
     leaveChatroom,
-    readyState,
   };
 }
 

--- a/containers/provider/SocketProvider.tsx
+++ b/containers/provider/SocketProvider.tsx
@@ -1,0 +1,54 @@
+import React, { useState, useEffect, FC, useCallback } from "react";
+import { io, Socket } from "socket.io-client";
+import SocketContext, {
+  SOCKET_EVENT,
+  SOCKET_URL,
+} from "@/contexts/SocketContext";
+import { Env, getEnv } from "@/lib/env";
+
+type Props = {
+  children: React.ReactNode;
+};
+const { internalEndpoint, env } = getEnv();
+
+export const SocketProvider: FC<Props> = ({ children }) => {
+  const [socket, setSocket] = useState<null | Socket>(null);
+
+  const connect = useCallback(() => {
+    if (socket?.connected) return;
+
+    const config =
+      env === Env.DEV
+        ? {
+            path: SOCKET_URL,
+            addTrailingSlash: false,
+          }
+        : {};
+
+    const newSocket = io(internalEndpoint, config);
+
+    newSocket
+      .on(SOCKET_EVENT.CONNECT, () => {
+        setSocket(newSocket);
+      })
+      .on(SOCKET_EVENT.DISCONNECT, () => {
+        setSocket(null);
+      });
+  }, [socket]);
+
+  const disconnect = useCallback(() => {
+    if (!socket?.connected) return;
+    socket.disconnect();
+  }, [socket]);
+
+  useEffect(() => {
+    connect();
+    return () => disconnect();
+  }, [connect, disconnect]);
+
+  return (
+    <SocketContext.Provider value={{ socket }}>
+      {children}
+    </SocketContext.Provider>
+  );
+};

--- a/containers/util/Startup.tsx
+++ b/containers/util/Startup.tsx
@@ -12,7 +12,7 @@ type Props = {
 const Startup: FC<Props> = ({ children, isAnonymous }) => {
   const { token, setToken, setCurrentUser, currentUser } = useAuth();
   const {
-    authentication,
+    // authentication,
     getTokenInCookie,
     updateTokenInCookie,
     getCurrentUser,

--- a/contexts/ChatroomContext.tsx
+++ b/contexts/ChatroomContext.tsx
@@ -6,7 +6,6 @@ const defaultValue: ChatroomContextType = {
   sendChatMessage: () => {},
   joinChatroom: () => {},
   leaveChatroom: () => {},
-  readyState: 0,
 };
 
 const ChatroomContext = createContext<ChatroomContextType>(defaultValue);

--- a/contexts/SocketContext.tsx
+++ b/contexts/SocketContext.tsx
@@ -1,0 +1,22 @@
+import { createContext } from "react";
+import { Socket } from "socket.io-client";
+
+type StoreContextType = {
+  socket: null | Socket;
+};
+
+export const SOCKET_URL = "/api/internal/socketio";
+
+export enum SOCKET_EVENT {
+  CONNECT = "connect",
+  DISCONNECT = "disconnect",
+  CHATROOM_JOIN = "CHATROOM_JOIN",
+  CHATROOM_LEAVE = "CHATROOM_LEAVE",
+  CHAT_MESSAGE = "CHAT_MESSAGE",
+}
+
+const SocketContext = createContext<StoreContextType>({
+  socket: null,
+});
+
+export default SocketContext;

--- a/hooks/context/useSocketCore.ts
+++ b/hooks/context/useSocketCore.ts
@@ -1,0 +1,8 @@
+import SocketContext from "@/contexts/SocketContext";
+import { useContext } from "react";
+
+const useSocketCore = () => {
+  return useContext(SocketContext);
+};
+
+export default useSocketCore;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "react-dom": "18.2.0",
     "react-i18next": "^13.0.2",
     "sharp": "0.32.1",
+    "socket.io": "^4.7.1",
+    "socket.io-client": "^4.7.1",
     "tailwind-merge": "1.13.2"
   },
   "devDependencies": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,6 +16,7 @@ import ApiHistoryList from "@/components/util/api-history/ApiHistoryList";
 import { Env, getEnv } from "@/lib/env";
 import { ToastQueueProvider } from "@/components/shared/Toast";
 import ChatroomContextProvider from "@/containers/provider/ChatroomProvider";
+import { SocketProvider } from "@/containers/provider/SocketProvider";
 
 export type NextPageWithProps<P = unknown, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -48,14 +49,16 @@ function App({ Component, pageProps }: AppWithProps) {
     <ToastQueueProvider>
       <AxiosProvider>
         <AuthProvider>
-          <ChatroomContextProvider>
-            {getHistory(
-              <Startup isAnonymous={isAnonymous}>
-                {getLayout(<Component {...pageProps} />)}
-                {!isProduction && <ApiHistoryList />}
-              </Startup>
-            )}
-          </ChatroomContextProvider>
+          <SocketProvider>
+            <ChatroomContextProvider>
+              {getHistory(
+                <Startup isAnonymous={isAnonymous}>
+                  {getLayout(<Component {...pageProps} />)}
+                  {!isProduction && <ApiHistoryList />}
+                </Startup>
+              )}
+            </ChatroomContextProvider>
+          </SocketProvider>
         </AuthProvider>
       </AxiosProvider>
     </ToastQueueProvider>

--- a/pages/api/mock/socket.ts
+++ b/pages/api/mock/socket.ts
@@ -1,8 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { WebSocket, WebSocketServer } from "ws";
-import { Socket_DispatchActionType } from "@/containers/provider/ChatroomProvider";
-
 import { MessageType } from "@/components/rooms/RoomChatroom";
+import { SOCKET_EVENT } from "@/contexts/SocketContext";
 
 type NextApiResponseServer = NextApiResponse & {
   socket: {
@@ -15,6 +14,11 @@ type NextApiResponseServer = NextApiResponse & {
 type User = NonNullable<MessageType["user"]>;
 
 type ConnectionType = Record<string, { user: User; ws: WebSocket }[]>;
+
+type Socket_DispatchActionType = {
+  type: keyof typeof SOCKET_EVENT;
+  payload: Record<string, any>;
+};
 
 type Response = Socket_DispatchActionType & { payload: MessageType };
 
@@ -37,28 +41,28 @@ export default function handler(
         const messageType = jsonData.type as Socket_DispatchActionType["type"];
 
         switch (messageType) {
-          case "CONNECTION_OPEN": {
-            // register the user to LOBBY chatroom
-            const user: User = jsonData.payload.user;
-            connections.LOBBY.push({ user, ws });
+          // case "CONNECTION_OPEN": {
+          //   // register the user to LOBBY chatroom
+          //   const user: User = jsonData.payload.user;
+          //   connections.LOBBY.push({ user, ws });
 
-            // produce response
-            const response: Response = {
-              type: "CHAT_MESSAGE",
-              payload: {
-                from: "SYSTEM",
-                content: `聊天室伺服器連線成功，加入大廳聊天室`,
-                timestamp: new Date().toISOString(),
-                to: "LOBBY",
-              },
-            };
+          //   // produce response
+          //   const response: Response = {
+          //     type: "CHAT_MESSAGE",
+          //     payload: {
+          //       from: "SYSTEM",
+          //       content: `聊天室伺服器連線成功，加入大廳聊天室`,
+          //       timestamp: new Date().toISOString(),
+          //       to: "LOBBY",
+          //     },
+          //   };
 
-            // broadcast the message to LOBBY chatroom
-            connections.LOBBY.forEach((connection) => {
-              connection.ws.send(JSON.stringify(response));
-            });
-            break;
-          }
+          //   // broadcast the message to LOBBY chatroom
+          //   connections.LOBBY.forEach((connection) => {
+          //     connection.ws.send(JSON.stringify(response));
+          //   });
+          //   break;
+          // }
           case "CHAT_MESSAGE": {
             // produce response
             const {
@@ -145,9 +149,9 @@ export default function handler(
             break;
           }
 
-          case "CONNECTION_CLOSE": {
-            break;
-          }
+          // case "CONNECTION_CLOSE": {
+          //   break;
+          // }
           default:
             throw new Error(`未預期的 type: ${messageType}`);
         }

--- a/pages/api/mock/socketio.ts
+++ b/pages/api/mock/socketio.ts
@@ -1,0 +1,72 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { Server as NetServer, Socket } from "net";
+import { Server as SocketIOServer, Server as ServerIO } from "socket.io";
+import { Server as HttpServer } from "http";
+import { SOCKET_EVENT, SOCKET_URL } from "@/contexts/SocketContext";
+
+export type NextApiResponseServerIO = NextApiResponse & {
+  socket: Socket & {
+    server: NetServer & {
+      io: SocketIOServer;
+    };
+  };
+};
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+const onlineUsers = new Map<string, string>();
+let isEmitting = false;
+let sendOnlineUsers: NodeJS.Timeout;
+
+const socketio = async (req: NextApiRequest, res: NextApiResponseServerIO) => {
+  if (!res.socket.server.io) {
+    // eslint-disable-next-line no-console
+    console.log("First connect on socket.io");
+    const httpServer: HttpServer = res.socket.server as any;
+    const io = new ServerIO(httpServer, {
+      path: SOCKET_URL,
+      addTrailingSlash: false,
+    });
+
+    io.on(SOCKET_EVENT.CONNECT, (socket) => {
+      // eslint-disable-next-line no-console
+      console.log("SOCKET CONNECTED IN SERVER! ", socket.id);
+      onlineUsers.set(socket.id, socket.id);
+
+      socket.on(SOCKET_EVENT.CHAT_MESSAGE, (message) => {
+        // eslint-disable-next-line no-console
+        console.log("Message received in server: ", message);
+        io.emit(SOCKET_EVENT.CHAT_MESSAGE, message);
+      });
+      socket.on(SOCKET_EVENT.DISCONNECT, () => {
+        onlineUsers.delete(socket.id);
+        // eslint-disable-next-line no-console
+        console.log("SOCKET DISCONNECTED IN SERVER! ", socket.id);
+        if (isEmitting && onlineUsers.size === 0) {
+          clearInterval(sendOnlineUsers);
+          isEmitting = false;
+        }
+        // avoid memory leak
+        if (!isEmitting) {
+          sendOnlineUsers = setInterval(
+            () => console.log("Online users: ", onlineUsers),
+            5000
+          );
+          isEmitting = true;
+        }
+      });
+    });
+
+    res.socket.server.io = io;
+  } else {
+    // eslint-disable-next-line no-console
+    console.log("Socket.io already running");
+  }
+  res.end();
+};
+
+export default socketio;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2299,6 +2299,11 @@
     ignore "^5.1.8"
     p-map "^4.0.0"
 
+"@socket.io/component-emitter@~3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
+  integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
+
 "@storybook/addon-actions@7.0.23":
   version "7.0.23"
   resolved "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-7.0.23.tgz"
@@ -3369,6 +3374,18 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
+"@types/cors@^2.8.12":
+  version "2.8.13"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.13.tgz#b8ade22ba455a1b8cb3b5d3f35910fd204f84f94"
+  integrity sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/detect-port@^1.3.0":
   version "1.3.3"
   resolved "https://registry.npmjs.org/@types/detect-port/-/detect-port-1.3.3.tgz"
@@ -3569,6 +3586,11 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-20.1.1.tgz"
   integrity sha512-uKBEevTNb+l6/aCQaKVnUModfEMjAl98lw2Si9P5y4hLu9tm6AlX2ZIoXZX6Wh9lJueYPrGPKk5WMCNHg/u6/A==
 
+"@types/node@>=10.0.0":
+  version "20.4.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.8.tgz#b5dda19adaa473a9bf0ab5cbd8f30ec7d43f5c85"
+  integrity sha512-0mHckf6D2DiIAzh8fM8f3HQCvMKDpK94YQ0DSVkfWTG9BZleYIWudw9cJxX8oCk9bM+vAkDyujDV6dmKHbvQpg==
+
 "@types/node@^14.14.31":
   version "14.18.51"
   resolved "https://registry.npmjs.org/@types/node/-/node-14.18.51.tgz"
@@ -3755,6 +3777,14 @@
     "@typescript-eslint/types" "5.59.9"
     "@typescript-eslint/visitor-keys" "5.59.9"
 
+"@typescript-eslint/scope-manager@5.60.0":
+  version "5.60.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.60.0.tgz#ae511967b4bd84f1d5e179bb2c82857334941c1c"
+  integrity sha512-hakuzcxPwXi2ihf9WQu1BbRj1e/Pd8ZZwVTG9kfbxAMZstKz8/9OoexIwnmLzShtsdap5U/CoQGRCWlSuPbYxQ==
+  dependencies:
+    "@typescript-eslint/types" "5.60.0"
+    "@typescript-eslint/visitor-keys" "5.60.0"
+
 "@typescript-eslint/scope-manager@6.1.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.1.0.tgz#a6cdbe11630614f8c04867858a42dd56590796ed"
@@ -3768,6 +3798,11 @@
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.9.tgz"
   integrity sha512-uW8H5NRgTVneSVTfiCVffBb8AbwWSKg7qcA4Ot3JI3MPCJGsB4Db4BhvAODIIYE5mNj7Q+VJkK7JxmRhk2Lyjw==
 
+"@typescript-eslint/types@5.60.0":
+  version "5.60.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.60.0.tgz#3179962b28b4790de70e2344465ec97582ce2558"
+  integrity sha512-ascOuoCpNZBccFVNJRSC6rPq4EmJ2NkuoKnd6LDNyAQmdDnziAtxbCGWCbefG1CNzmDvd05zO36AmB7H8RzKPA==
+
 "@typescript-eslint/types@6.1.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.1.0.tgz#2d607c62827bb416ada5c96ebfa2ef84e45a8dfa"
@@ -3780,6 +3815,19 @@
   dependencies:
     "@typescript-eslint/types" "5.59.9"
     "@typescript-eslint/visitor-keys" "5.59.9"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.60.0":
+  version "5.60.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.60.0.tgz#4ddf1a81d32a850de66642d9b3ad1e3254fb1600"
+  integrity sha512-R43thAuwarC99SnvrBmh26tc7F6sPa2B3evkXp/8q954kYL6Ro56AwASYWtEEi+4j09GbiNAHqYwNNZuNlARGQ==
+  dependencies:
+    "@typescript-eslint/types" "5.60.0"
+    "@typescript-eslint/visitor-keys" "5.60.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -3819,6 +3867,14 @@
   integrity sha512-bT7s0td97KMaLwpEBckbzj/YohnvXtqbe2XgqNvTl6RJVakY5mvENOTPvw5u66nljfZxthESpDozs86U+oLY8Q==
   dependencies:
     "@typescript-eslint/types" "5.59.9"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.60.0":
+  version "5.60.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.60.0.tgz#b48b29da3f5f31dd1656281727004589d2722a66"
+  integrity sha512-wm9Uz71SbCyhUKgcaPRauBdTegUyY/ZWl8gLwD/i/ybJqscrrdVSFImpvUz16BLPChIeKBK5Fa9s6KDQjsjyWw==
+  dependencies:
+    "@typescript-eslint/types" "5.60.0"
     eslint-visitor-keys "^3.3.0"
 
 "@typescript-eslint/visitor-keys@6.1.0":
@@ -3986,9 +4042,9 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-accepts@~1.3.5, accepts@~1.3.8:
+accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
   version "1.3.8"
-  resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
   integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
   dependencies:
     mime-types "~2.1.34"
@@ -4579,6 +4635,11 @@ base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+base64id@2.0.0, base64id@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/base64id/-/base64id-2.0.0.tgz#2770ac6bc47d312af97a8bf9a634342e0cd25cb6"
+  integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
 
 bash-parser@^0.5.0:
   version "0.5.0"
@@ -5372,6 +5433,11 @@ cookie@0.5.0:
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
+cookie@~0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
 core-js-compat@^3.25.1, core-js-compat@^3.30.1, core-js-compat@^3.30.2:
   version "3.30.2"
   resolved "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.30.2.tgz"
@@ -5398,6 +5464,14 @@ core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+cors@~2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 cosmiconfig@^7.0.1:
   version "7.1.0"
@@ -5671,7 +5745,7 @@ debug@2.6.9, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -6130,6 +6204,38 @@ endent@^2.0.1:
     dedent "^0.7.0"
     fast-json-parse "^1.0.3"
     objectorarray "^1.0.5"
+
+engine.io-client@~6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-6.5.2.tgz#8709e22c291d4297ae80318d3c8baeae71f0e002"
+  integrity sha512-CQZqbrpEYnrpGqC07a9dJDz4gePZUgTPMU3NKJPSeQOyw27Tst4Pl3FemKoFGAlHzgZmKjoRmiJvbWfhCXUlIg==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.1"
+    engine.io-parser "~5.2.1"
+    ws "~8.11.0"
+    xmlhttprequest-ssl "~2.0.0"
+
+engine.io-parser@~5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.2.1.tgz#9f213c77512ff1a6cc0c7a86108a7ffceb16fcfb"
+  integrity sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==
+
+engine.io@~6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.5.2.tgz#769348ced9d56bd47bd83d308ec1c3375e85937c"
+  integrity sha512-IXsMcGpw/xRfjra46sVZVHiSWo/nJ/3g1337q9KNXtS6YRzbW5yIzTCb9DjhrBe7r3GZQR0I4+nq+4ODk5g/cA==
+  dependencies:
+    "@types/cookie" "^0.4.1"
+    "@types/cors" "^2.8.12"
+    "@types/node" ">=10.0.0"
+    accepts "~1.3.4"
+    base64id "2.0.0"
+    cookie "~0.4.1"
+    cors "~2.8.5"
+    debug "~4.3.1"
+    engine.io-parser "~5.2.1"
+    ws "~8.11.0"
 
 enhanced-resolve@^5.12.0, enhanced-resolve@^5.14.1, enhanced-resolve@^5.7.0:
   version "5.14.1"
@@ -9538,9 +9644,9 @@ nwsapi@^2.2.2:
   resolved "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.5.tgz"
   integrity sha512-6xpotnECFy/og7tKSBVmUNft7J3jyXAka4XvG6AUhFWRz+Q/Ljus7znJAA3bxColfQLdS+XsjoodtJfCgeTEFQ==
 
-object-assign@^4.0.1, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 object-hash@^3.0.0:
@@ -11192,6 +11298,44 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
+socket.io-adapter@~2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz#5de9477c9182fdc171cd8c8364b9a8894ec75d12"
+  integrity sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==
+  dependencies:
+    ws "~8.11.0"
+
+socket.io-client@^4.7.1:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.7.2.tgz#f2f13f68058bd4e40f94f2a1541f275157ff2c08"
+  integrity sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.2"
+    engine.io-client "~6.5.2"
+    socket.io-parser "~4.2.4"
+
+socket.io-parser@~4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.4.tgz#c806966cf7270601e47469ddeec30fbdfda44c83"
+  integrity sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.1"
+
+socket.io@^4.7.1:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.7.2.tgz#22557d76c3f3ca48f82e73d68b7add36a22df002"
+  integrity sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==
+  dependencies:
+    accepts "~1.3.4"
+    base64id "~2.0.0"
+    cors "~2.8.5"
+    debug "~4.3.2"
+    engine.io "~6.5.2"
+    socket.io-adapter "~2.5.2"
+    socket.io-parser "~4.2.4"
+
 source-map-js@^1.0.1, source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz"
@@ -12215,9 +12359,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
-  resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
 verror@1.10.0:
@@ -12509,6 +12653,11 @@ ws@^7.3.1:
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
+ws@~8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
+  integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
+
 xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz"
@@ -12518,6 +12667,11 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xmlhttprequest-ssl@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz#91360c86b914e67f44dce769180027c0da618c67"
+  integrity sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==
 
 xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION

## Why need this change? / Root cause:
### 這隻 PR & branch 是從這邊分出來的：[Here](https://github.com/Game-as-a-Service/Game-Lobby-Web/pull/249)，因為寫一寫忘記切 branch 出來導致弄亂了 @arealclimber 的分支還真不好意思，基本上這支 PR 只是在上面這支 PR 多做一點微調與調整 commit 而已，完整資訊請查閱以上 PR。

- ... [PR 249](https://github.com/Game-as-a-Service/Game-Lobby-Web/pull/249#issue-1806544895) 
- Moved Socket Constants to file `@/contexts/SocketContext`
- Encapsulated connect logic to function to be used flexibly in other components
- Added console in mock socket server to show online (dev mode) users

## Changes made:

- Follow our codestyle to new `useSocketCore.ts` .
- Encapsulate connect logic in `SocketProvider.ts` as a function.
- Move Socket some constants to `SocketContext.tsx`

## Test Scope / Change impact:

-

## Issue

- #239 
- #249 
