### PR TITLE
fix: context lost after navigated

### DIFF
--- a/containers/provider/AuthProvider.tsx
+++ b/containers/provider/AuthProvider.tsx
@@ -14,7 +14,7 @@ const AuthProvider: FC<Props> = ({ children }) => {
     <AuthContext.Provider
       value={{
         token,
-        setToken: (token: string | undefined | null) => setToken(token),
+        setToken,
         currentUser,
         setCurrentUser: (currentUser: UserInfo | null) =>
           setCurrentUser(currentUser),

--- a/containers/room/RoomListView.tsx
+++ b/containers/room/RoomListView.tsx
@@ -85,8 +85,8 @@ const RoomsListView: FC<Props> = ({ status }) => {
         })
         .finally(() => {
           // setSelectedRoom(undefined);
-          setIsLoading(false);
           setPasswordValues(INIT_PASSWORD);
+          isLoading && setIsLoading(false);
         });
     }
 
@@ -94,7 +94,7 @@ const RoomsListView: FC<Props> = ({ status }) => {
     if (!selectedRoom.isLocked || passwordValues.every((char) => char !== "")) {
       fetchRoomEntry(selectedRoom.id);
     }
-  }, [selectedRoom, passwordValues, isLoading, router, fetch]);
+  }, [selectedRoom, passwordValues, isLoading, router, fetch, firePopup, t]);
 
   const Pagination = () => {
     return (

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -8,6 +8,7 @@ import { getCurrentUser as getCurrentUserReq } from "@/requests/users/index";
 import useRequest from "./useRequest";
 import useAuth from "./context/useAuth";
 import useCookie from "./useCookie";
+import { useCallback } from "react";
 
 const useUser = () => {
   const { fetch } = useRequest();
@@ -26,13 +27,16 @@ const useUser = () => {
     return await fetch(authenticationReq(token));
   };
 
-  const login = (token: string) => {
-    setTokenCtx(token);
-  };
+  const login = useCallback(
+    (token: string) => {
+      setTokenCtx(token);
+    },
+    [setTokenCtx]
+  );
 
-  const logout = () => {
+  const logout = useCallback(() => {
     setTokenCtx(null);
-  };
+  }, [setTokenCtx]);
 
   const getTokenInCookie = () => {
     return tokenOperator.get();

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -1,5 +1,7 @@
 import { ReactElement, useEffect } from "react";
 import { useRouter } from "next/router";
+import { GetStaticProps } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 import { NextPageWithProps } from "../_app";
 import useUser from "@/hooks/useUser";
@@ -27,3 +29,11 @@ Login.getLayout = (page: ReactElement) => page;
 Login.Anonymous = true;
 
 export default Login;
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale ?? "zh-TW", [""])),
+    },
+  };
+};

--- a/pages/auth/token/[token].tsx
+++ b/pages/auth/token/[token].tsx
@@ -1,5 +1,7 @@
 import { ReactElement, useEffect } from "react";
 import { useRouter } from "next/router";
+import { GetStaticProps, GetStaticPaths } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 import { NextPageWithProps } from "@/pages/_app";
 import useUser from "@/hooks/useUser";
@@ -25,3 +27,18 @@ Token.getLayout = (page: ReactElement) => page;
 Token.Anonymous = true;
 
 export default Token;
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: true,
+  };
+};
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale ?? "zh-TW", [""])),
+    },
+  };
+};

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,5 +1,7 @@
 import { SyntheticEvent, useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import { GetStaticProps } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 import Button from "@/components/shared/Button";
 import Cover from "@/components/shared/Cover";
@@ -26,7 +28,7 @@ const Login: NextPageWithProps = () => {
     } else {
       setCheckAuth(true);
     }
-  }, [token]);
+  }, [token, push]);
 
   const onLoginClick = async (e: SyntheticEvent, type: LoginType) => {
     if (isMock) {
@@ -35,7 +37,7 @@ const Login: NextPageWithProps = () => {
 
       const endpoint = await getLoginEndpoint(type);
       // mock: redirect to /auth/token
-      window.location.href = endpoint.url;
+      push(endpoint.url);
     }
   };
 
@@ -95,3 +97,11 @@ Login.getLayout = (page) => (
 );
 
 export default Login;
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale ?? "zh-TW", [""])),
+    },
+  };
+};

--- a/pages/rooms/[roomId]/index.tsx
+++ b/pages/rooms/[roomId]/index.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/router";
+import { GetStaticProps, GetStaticPaths } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import RoomUserCardList from "@/components/rooms/RoomUserCardList";
 import RoomButtonGroup from "@/components/rooms/RoomButtonGroup";
 import RoomBreadcrumb from "@/components/rooms/RoomBreadcrumb";
@@ -178,3 +180,18 @@ export default function Room() {
     </section>
   );
 }
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: true,
+  };
+};
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale ?? "zh-TW", [""])),
+    },
+  };
+};


### PR DESCRIPTION

## Why need this change? / Root cause:
- [Discussion](https://github.com/Game-as-a-Service/Game-Lobby-Web/discussions/260)
- The context gets reset when switching between page components that do not use the serverSideTranslations function to load staticProps
- Reference: [i18next #1683](https://github.com/i18next/next-i18next/issues/1683)

## Changes made:

- Apply serverSideTranslations function to every page component.
- Fix some ESLint warning.

## Test Scope / Change impact:

-

## Issue

-
