### PR TITLE
fix: LHCI Failure

### DIFF
--- a/containers/provider/SocketProvider.tsx
+++ b/containers/provider/SocketProvider.tsx
@@ -23,7 +23,7 @@ export const SocketProvider: FC<Props> = ({ children }) => {
     if (socket?.connected) return;
 
     const config =
-      env === Env.DEV
+      env === Env.DEV || process.env.NEXT_PUBLIC_CI_MODE
         ? {
             path: SOCKET_URL,
             addTrailingSlash: false,


### PR DESCRIPTION
## Why need this change? / Root cause:

- The CI pipeline is currently failing due to the absence of the mock Sokcet.IO server during CI mode. 
![image](https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/114204927/99ca8558-e5e7-4f36-8985-eebc84d10ddb)


## Changes made:

- Modified the WebSocket server configuration logic to ensure the mock Sokcet.IO server is started not only in development mode but also in CI mode.

## Test Scope / Change impact:

-

## Issue

- #270 

-  #261 感謝 @ttpss930141011 在此 PR 中數次分享測試的結果，縮小了釐清本次議題所需要思考的範籌，沒有你的分享可能不會這麼快想到解方。
