### PR TITLE
fix: socket couldn't disconnect during leaving or refreshing page

### DIFF
--- a/components/rooms/RoomChatroom/RoomChatroom.tsx
+++ b/components/rooms/RoomChatroom/RoomChatroom.tsx
@@ -10,13 +10,8 @@ type RoomChatroom = {
 };
 
 export default function RoomChatroom({ roomId }: RoomChatroom) {
-  const {
-    lastMessage,
-    sendChatMessage,
-    joinChatroom,
-    leaveChatroom,
-    // readyState,
-  } = useChatroom();
+  const { lastMessage, sendChatMessage, joinChatroom, leaveChatroom } =
+    useChatroom();
   const { socket } = useSocketCore();
   const scrollbarRef = useRef<HTMLDivElement | null>(null);
   const [inputValue, setInputValue] = useState<string>("");

--- a/contexts/SocketContext.tsx
+++ b/contexts/SocketContext.tsx
@@ -1,11 +1,33 @@
+import { Env, getEnv } from "@/lib/env";
 import { createContext } from "react";
-import { Socket } from "socket.io-client";
+import { Socket, io } from "socket.io-client";
 
 type StoreContextType = {
-  socket: null | Socket;
+  socket: Socket;
 };
 
+const { internalEndpoint, env } = getEnv();
+
 export const SOCKET_URL = "/api/internal/socketio";
+
+const config =
+  env === Env.DEV || process.env.NEXT_PUBLIC_CI_MODE
+    ? {
+        path: SOCKET_URL,
+        addTrailingSlash: false,
+        autoConnect: false,
+        reconnection: true,
+        reconnectionDelay: 10000,
+        reconnectionDelayMax: 10000,
+        reconnectionAttempts: Infinity,
+      }
+    : {
+        autoConnect: false,
+        reconnection: true,
+        reconnectionDelay: 10000,
+        reconnectionDelayMax: 10000,
+        reconnectionAttempts: Infinity,
+      };
 
 export enum SOCKET_EVENT {
   CONNECT = "connect",
@@ -23,8 +45,8 @@ export enum SOCKET_EVENT {
   ROOM_CLOSED = "ROOM_CLOSED",
 }
 
-const SocketContext = createContext<StoreContextType>({
-  socket: null,
-});
+export const socket = io(internalEndpoint, config);
+
+const SocketContext = createContext<StoreContextType>({ socket });
 
 export default SocketContext;

--- a/pages/api/mock/socketio.ts
+++ b/pages/api/mock/socketio.ts
@@ -125,6 +125,8 @@ const socketio = async (req: NextApiRequest, res: NextApiResponseServerIO) => {
         io.emit(SOCKET_EVENT.CHAT_MESSAGE, message);
       });
       socket.on(SOCKET_EVENT.DISCONNECT, () => {
+        // eslint-disable-next-line no-console
+        console.log("SOCKET DISCONNECTED FROM SERVER! ", socket.id);
         onlineUsers.delete(socket.id);
         if (isEmitting && onlineUsers.size === 0) {
           clearInterval(sendOnlineUsers);


### PR DESCRIPTION
## Why need this change? / Root cause:

- We didn't add disconnect action when page refresh or leave. It caused server will keep unuse socket connections.
- We didn't add **reconnectionDelay** in socket config. It caused backend developr feel hard when debugging.
- We didn't add **autoConnect** in socket config. It caused some unstable connections when we manually handle connect like us.

## Changes made:

- Add **beforeunload EventListener** to handle refreshing or leaving state.
- Add reconnectionDelay & autoConnect in socket config.

## Test Scope / Change impact:

-

## Issue

- #285 

## Note

原本這個分支是想用來試試看將 Socket 放進 Store 持久化，結果遇到兩個困難：

1. Zustand Store definition is pure JS. 無法在連接時 addWsHistory Event，硬要使用也是套一個 HOC，那我就用維持現狀就好啦
> Ref: [Zustand document](https://docs.pmnd.rs/zustand/getting-started/comparison#redux) , https://github.com/pmndrs/zustand/discussions/1308

2. 如 @Yuwen-ctw 所預期，出現了循環引用的問題：
```
Uncaught (in promise) TypeError: Converting circular structure to JSON --> starting at object with constructor 'Socket' | property 'io' -> object with constructor 'Manager' | property 'nsps' -> object with constructor 'Object' --- property '/' closes the circle at JSON.stringify (<anonymous>)
```
剛好在找第一個困難的解答時看到了 Redux Q&A 裡有提到 Websocket 的實踐部分，提到 Socket 並不是 serializable，所以不應成為狀態，最好的位置在 Middleware

![image](https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/23444218/f44111dd-82b7-4f5d-aaf0-09c8ba77e588)
> Ref: https://redux.js.org/faq/code-structure#where-should-websockets-and-other-persistent-connections-live

裡面還有提供其他人的實踐的 Middleware：
![image](https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/23444218/2f9dad60-e7b6-4a61-b1f5-c3822e2334d4)

> Ref: [Redux Q&A](https://redux.js.org/faq/code-structure#where-should-websockets-and-other-persistent-connections-live), [redux-ecosystem-links](https://github.com/markerikson/redux-ecosystem-links/tree/master)

## Eventually
- make persistent web socket connection **across** page refresh 有可能會有些安全漏洞。(Ref: [Stack overflow](https://stackoverflow.com/questions/68480890/how-to-make-persistent-web-socket-connection-across-page-refresh-in-a-secure-way))
- 我們應該未來會實踐持久會話ID，如 Socket.IO 官方的範例中效果一樣。(Ref: [Private messaging - Part II](https://socket.io/get-started/private-messaging-part-2/#persistent-session-id))