### PR TITLE
fix: modify DEFAULT_PAGE from 1 to 0 in usePagination hook

### DIFF
--- a/hooks/usePagination.ts
+++ b/hooks/usePagination.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { PageData } from "@/requests/rooms";
-import axios, { AxiosError } from "axios";
+import axios from "axios";
 
-const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE = 0;
 
 const usePagination = <T>(option: {
   source: (page: number, perPage: number) => Promise<PageData<T>>;


### PR DESCRIPTION
## Why need this change? / Root cause:

- To ensure accurate data listing, unify the initial page number from 1 to 0.

## Changes made:

- 

## Test Scope / Change impact:

-

## Issue

- Closes  #287 
