### PR TITLE
fix: dependabot ci failure issue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[RENOVATE-BOT] "
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[RENOVATE-BOT] "

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -23,6 +23,7 @@ jobs:
               { keyword: 'refactor', label: 'refactor' },
               { keyword: 'fix', label: 'bug' },
               { keyword: '[RENOVATE-BOT]', label: 'dependency upgrade' },
+              { keyword: '[DEPENDA-BOT]', label: 'dependency alerts' },
             ];
 
             // Collect all labels that should be added according to the title


### PR DESCRIPTION
## Why need this change?:

- The PR Auto Labeler / label (pull_request) CI in PR rised by [dependabot](https://github.com/apps/dependabot) would fail.

## Root cause:

- We didn't accept the PR title `chore(deps): ` in auto-label workflow.

## Changes made:

- In order to follow this rule of naming dependent robots, I added `[DEPENDA-BOT] ` in dependabot config file, and added labelsRules in auto-label.ci to detect PR prefix.

> ref: [commit-message](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message)

## Test Scope / Change impact:

-

## Issue

- #301 
