### PR TITLE
fix: 🔧 unset image optimization

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,7 +16,7 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   images: {
-    domains: ["localhost", "images.unsplash.com"],
+    unoptimized: true,
   },
   webpack(config) {
     config.module.rules.push({


### PR DESCRIPTION
## Why need this change? / Root cause:

- Fixing the issue of external images not displaying.
- Reducing server traffic generated by image optimization.

## Changes made:

- next.config.js

## Test Scope / Change impact:

-

## Issue

- Close #316 

## Note

關於之前說 image 優化是否會造成 server 流量增加，我後來查閱了官方文件與原始碼，發現使用外部圖片時，會 fetch 外部圖片並進行圖片優化，故應該是會造成 server 流量增加，所以目前的解決方案改成取消圖片優化 (image optimization) 這個功能，未來如果有效能問題或想優化本地圖片，可以慢慢針對特定圖片進行優化，如 `<Image unoptimized={false} />`。

### Reference

- [minimizing-image-optimization-costs](https://vercel.com/docs/image-optimization/managing-image-optimization-costs#minimizing-image-optimization-costs)
- [billing](https://vercel.com/docs/image-optimization/limits-and-pricing#billing)
- [image-optimizer](https://github.com/vercel/next.js/blob/v12.0.10/packages/next/server/image-optimizer.ts#L233)