### PR TITLE
feat: Socket.IO connects with the jwt token

### DIFF
--- a/components/rooms/RoomChatroom/RoomChatroom.tsx
+++ b/components/rooms/RoomChatroom/RoomChatroom.tsx
@@ -23,7 +23,7 @@ export default function RoomChatroom({ roomId }: RoomChatroom) {
     if (!socket || !socket.connected) return;
     joinChatroom(roomId);
     return () => leaveChatroom(roomId);
-  }, [joinChatroom, leaveChatroom, roomId, socket, socket.connected]);
+  }, [joinChatroom, leaveChatroom, roomId, socket, socket?.connected]);
 
   // update message list while received new message from websocket
   useEffect(() => {

--- a/contexts/SocketContext.tsx
+++ b/contexts/SocketContext.tsx
@@ -2,10 +2,6 @@ import { Env, getEnv } from "@/lib/env";
 import { createContext } from "react";
 import { Socket, io } from "socket.io-client";
 
-type StoreContextType = {
-  socket: Socket;
-};
-
 const { internalEndpoint, env } = getEnv();
 
 export const SOCKET_URL = "/api/internal/socketio";
@@ -45,8 +41,16 @@ export enum SOCKET_EVENT {
   ROOM_CLOSED = "ROOM_CLOSED",
 }
 
-export const socket = io(internalEndpoint, config);
+export const createSocket = (token: string | null | undefined) => {
+  return io(internalEndpoint, { auth: { token }, ...config });
+};
 
-const SocketContext = createContext<StoreContextType>({ socket });
+type StoreContextType = {
+  socket: Socket | null;
+};
+
+const SocketContext = createContext<StoreContextType>({
+  socket: null,
+});
 
 export default SocketContext;

--- a/pages/api/mock/socketio.ts
+++ b/pages/api/mock/socketio.ts
@@ -22,6 +22,17 @@ const onlineUsers = new Map<string, string>();
 let isEmitting = false;
 let sendOnlineUsers: NodeJS.Timeout;
 
+function registeringMiddleware(io: ServerIO) {
+  io.use((socket, next) => {
+    const token = socket.handshake.auth.token;
+    if (token == undefined) {
+      next(new Error("not authorized"));
+    } else {
+      next();
+    }
+  });
+}
+
 const socketio = async (req: NextApiRequest, res: NextApiResponseServerIO) => {
   if (!res.socket.server.io) {
     // eslint-disable-next-line no-console
@@ -32,14 +43,7 @@ const socketio = async (req: NextApiRequest, res: NextApiResponseServerIO) => {
       addTrailingSlash: false,
     });
 
-    io.use((socket, next) => {
-      const token = socket.handshake.auth.token;
-      if (token == undefined) {
-        next(new Error("not authorized"));
-      } else {
-        next();
-      }
-    });
+    registeringMiddleware(io);
 
     io.on(SOCKET_EVENT.CONNECT, (socket) => {
       // eslint-disable-next-line no-console

--- a/pages/api/mock/socketio.ts
+++ b/pages/api/mock/socketio.ts
@@ -34,7 +34,11 @@ const socketio = async (req: NextApiRequest, res: NextApiResponseServerIO) => {
 
     io.use((socket, next) => {
       const token = socket.handshake.auth.token;
-      next();
+      if (token == undefined) {
+        next(new Error("not authorized"));
+      } else {
+        next();
+      }
     });
 
     io.on(SOCKET_EVENT.CONNECT, (socket) => {

--- a/pages/api/mock/socketio.ts
+++ b/pages/api/mock/socketio.ts
@@ -32,6 +32,11 @@ const socketio = async (req: NextApiRequest, res: NextApiResponseServerIO) => {
       addTrailingSlash: false,
     });
 
+    io.use((socket, next) => {
+      const token = socket.handshake.auth.token;
+      next();
+    });
+
     io.on(SOCKET_EVENT.CONNECT, (socket) => {
       // eslint-disable-next-line no-console
       console.log("SOCKET CONNECTED IN SERVER! ", socket.id);


### PR DESCRIPTION
## Why need this change? / Root cause:

- Socket.IO connects with the jwt token

## Changes made:

- When the user's token changes, Socket.IO will automatically reconnect using the new token.
- Socker.IO dev server can get token

## Test Scope / Change impact:

-

## Issue

- Close #318

## Note

原本的 Socket.IO 是固定參數，這次需求改為動態帶 auth token

### Reference

https://socket.io/docs/v4/middlewares/#sending-credentials