### PR TITLE
🐛 fix production external images not displaying

### DIFF
--- a/components/shared/Avatar/Avatar.tsx
+++ b/components/shared/Avatar/Avatar.tsx
@@ -111,6 +111,7 @@ export default function Avatar({
         height={avatarSize}
         className={avatarClassName}
         onError={handleImageError}
+        unoptimized
       />
     );
 


### PR DESCRIPTION
## Why need this change? / Root cause:

- fix production external images not displaying

## Changes made:

-

## Test Scope / Change impact:

- Avater component image

## Issue

- Close #316 

## Note

不知道為什麼部屬在預覽網站可以正常顯示照片，部屬到正式機後卻沒吃到 `next.config.js` 的 image unoptimized 設定，所以我目前先暫時調整 Avater 裡面的 image 個別設定 unoptimized，有時間再研究為什麼 `next.config.js` 的 `unoptimized` 設定會失效

### 預覽版的登入頁
![image](https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/86179381/c7ae1f1b-2dcb-4a83-b4ae-143fd728d902)

### 正式機的登入頁
![image](https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/86179381/66409673-2cfb-494b-8787-f599409945b4)

