### PR TITLE
fix: dependabot ci failure issue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "[DEPENDA-BOT] "
+
+  # Maintain dependencies for npm
+  # only update dependencies that are very urgent
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[DEPENDA-BOT] "
+    open-pull-requests-limit: 0

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -23,6 +23,7 @@ jobs:
               { keyword: 'refactor', label: 'refactor' },
               { keyword: 'fix', label: 'bug' },
               { keyword: '[RENOVATE-BOT]', label: 'dependency upgrade' },
+              { keyword: '[DEPENDA-BOT]', label: 'dependency alerts' },
             ];
 
             // Collect all labels that should be added according to the title


### PR DESCRIPTION
## Why need this change?:

- The PR Auto Labeler / label (pull_request) CI in PR rised by [dependabot](https://github.com/apps/dependabot) would fail.

## Root cause:

- We didn't accept the PR title `chore(deps)` or `chore(deps-dev)` in auto-label workflow.

## Changes made:

- In order to follow this rule of naming dependent robots, I added `[DEPENDA-BOT] ` in dependabot config file, and added labelsRules in auto-label.ci to detect PR prefix.

> ref: [commit-message](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message)

## Test Scope / Change impact:

-

## Issue

- #301 

## Notes

In fact, I rised the same PR #302 before, but it exceeded my expectations because it rised a lot of PRs to update the package like RENOVATE-BOT (and actually the PR prefix was wrong XD). So I reverted that PR finally.

<img width="500" alt="image" src="https://github.com/Game-as-a-Service/Game-Lobby-Web/assets/23444218/24022d01-818f-49b6-9fc7-b32951b98b0e">

In this PR, I added `open-pull-requests-limit: 0` in config. This setting will prevent dependabot from making PRs except for some security exceptions that must be updated.

> ref: [How to get dependabot to trigger for security updates only](https://stackoverflow.com/questions/64047526/how-to-get-dependabot-to-trigger-for-security-updates-only)
