### PR TITLE
fix: use useSearchParams for token retrieval instead use useRouter

### DIFF
--- a/pages/auth/token/[token].tsx
+++ b/pages/auth/token/[token].tsx
@@ -2,17 +2,15 @@ import { ReactElement, useEffect } from "react";
 import { useRouter } from "next/router";
 import { GetStaticProps, GetStaticPaths } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-
 import { NextPageWithProps } from "@/pages/_app";
 import useUser from "@/hooks/useUser";
 
 const Token: NextPageWithProps = () => {
-  const {
-    query: { token },
-    push,
-  } = useRouter();
-  const { login } = useUser();
+  const { push, asPath } = useRouter();
+  const regex = /^\/auth\/token\/(.+)$/;
+  const token = asPath.match(regex)?.[1];
 
+  const { login } = useUser();
   useEffect(() => {
     if (token) {
       login(token as string);


### PR DESCRIPTION
## Why need this change? / Root cause:
- Changed implementation due to an issue where the token retrieved from query was not as expected


## Changes made:

- Replaced `useRouter().query` with `useRouter().asPath` to retrieve the `token` parameter

## Test Scope / Change impact:

-

## Issue

- close #390 
