### PR TITLE
feat: try to read room info first before join room

### DIFF
--- a/containers/room/RoomListView.tsx
+++ b/containers/room/RoomListView.tsx
@@ -9,6 +9,7 @@ import {
   RoomType,
   getRooms,
   postRoomEntry,
+  getRoomInfoEndpoint,
 } from "@/requests/rooms";
 import Button from "@/components/shared/Button";
 import RoomCard from "@/components/rooms/RoomCard";
@@ -73,6 +74,11 @@ const RoomsListView: FC<Props> = ({ status }) => {
   useEffect(() => {
     async function fetchRoomEntry(_roomId: string) {
       setIsLoading(true);
+
+      if (await fetch(getRoomInfoEndpoint(_roomId)).catch(() => {})) {
+        router.push(`/rooms/${_roomId}`);
+        return;
+      }
 
       fetch(postRoomEntry(_roomId, passwordValues.join("")))
         .then(() => {


### PR DESCRIPTION
## Why need this change? / Root cause:

- when user enter and leave the room page, they can not go back through current rooms page ui

## Changes made:

- check room info first, if success, means the user is already been in the room
- try to previous process otherwise.

## Test Scope / Change impact:

- fetch api will alert status 400 in the console even catch it

## Issue

-
