### PR TITLE
feat: Implement socket connection status indicator in Header

### DIFF
--- a/.github/workflows/build-and-deploy-storybook.yaml
+++ b/.github/workflows/build-and-deploy-storybook.yaml
@@ -52,6 +52,6 @@ jobs:
           path: storybook-static
 
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4
         with:
           token: ${{ github.token }}

--- a/components/shared/Header.tsx
+++ b/components/shared/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, ReactNode } from "react";
 import Icon, { IconName } from "@/components/shared/Icon";
 import Badge from "@/components/shared/Badge";
 import { cn } from "@/lib/utils";
@@ -24,12 +24,14 @@ interface HeaderProps {
   className?: string;
   isChatVisible: boolean;
   onClickChatButton: () => void;
+  socketStatusIndicator?: ReactNode;
 }
 
 export default function Header({
   className,
   isChatVisible,
   onClickChatButton,
+  socketStatusIndicator,
 }: Readonly<HeaderProps>) {
   const [isUserInfoVisible, setIsUserInfoVisible] = useState(false);
   const { currentUser } = useAuth();
@@ -68,7 +70,10 @@ export default function Header({
         <Image src="/logo.png" alt="logo" width={40} height={40} priority />
         <h2 className="text-primary-100 text-2xl">遊戲微服務大平台</h2>
       </div>
-      <div className="header___actions flex gap-5">
+      <div className="header___actions flex items-center gap-5">
+        {socketStatusIndicator && (
+          <div className="mr-2">{socketStatusIndicator}</div>
+        )}
         {buttons.map(({ type, iconName, isActive, onClick }) => (
           <Badge
             dot

--- a/contexts/SocketContext.tsx
+++ b/contexts/SocketContext.tsx
@@ -1,7 +1,7 @@
 import { Env, getEnv } from "@/lib/env";
 import { createContext } from "react";
 import { Socket, io } from "socket.io-client";
-import { SocketService } from "@/services/socket";
+import socketService from "@/services/socket";
 
 const { internalSocketEndpoint, env, isMock } = getEnv();
 
@@ -45,12 +45,12 @@ export const createSocket = (token: string | null | undefined) => {
 };
 
 type StoreContextType = {
-  socketService: SocketService;
+  socketService: typeof socketService;
   socket: Socket | null; // Kept for backward compatibility
 };
 
 const SocketContext = createContext<StoreContextType>({
-  socketService: SocketService.getInstance(),
+  socketService,
   socket: null,
 });
 

--- a/services/socket/index.ts
+++ b/services/socket/index.ts
@@ -9,41 +9,6 @@
  */
 
 // Export services
-export { BaseSocketService } from "./BaseSocketService";
-export { SocketService } from "./SocketService";
-export {
-  RoomSocketService,
-  createRoomSocketService,
-} from "./RoomSocketService";
-export {
-  ChatSocketService,
-  createChatSocketService,
-} from "./ChatSocketService";
-export {
-  GameSocketService,
-  createGameSocketService,
-} from "./GameSocketService";
+import { SocketService } from "./SocketService";
 
-// Export types and utilities
-export * from "./utils";
-
-/**
- * Socket Service Architecture
- *
- * The socket service follows a hierarchical organization:
- *
- * 1. BaseSocketService - Core socket functionality
- *    ↑
- * 2. Specialized Services - Domain-specific implementations
- *    - RoomSocketService - Room management
- *    - ChatSocketService - Chat functionality
- *    - GameSocketService - Game events
- *    ↑
- * 3. SocketService - Coordinates all specialized services
- *
- * Each service provides type-safe event handling with proper
- * resource management to prevent memory leaks.
- *
- * The API is designed to be intuitive and consistent across services,
- * while also providing specialized functionality for each domain.
- */
+export default SocketService.getInstance();


### PR DESCRIPTION
## Why need this change? / Root cause:

- 用戶需要知道實時連接狀態，以便了解網路問題或服務中斷
- 當 socket 斷線時，用戶無法知道為何部分功能無法正常運作
- 目前沒有視覺化方式顯示 socket 連接狀態

## Changes made:

- 新增socket連接狀態指示器組件，包含四種狀態：連線中、已連線、已斷線、連線錯誤
- 在 Header 組件中添加了 socketStatusIndicator 插槽，用於顯示連接狀態
- 在 AppLayout 中實現 socket 狀態監聽，並根據連接事件更新狀態
- 用不同顏色區分不同連接狀態：綠色(已連線)、紅色(已斷線)、黃色(錯誤)、灰色(連線中)

## Test Scope / Change impact:

- 測試各種網路狀況下的狀態指示器行為
- 確保在socket連接、斷開和錯誤時正確顯示對應狀態
- 確認在不同設備和螢幕尺寸下的顯示效果
- 檢查無障礙性支持，確保狀態變更有足夠的對比度和可讀性

## Issue

- none
